### PR TITLE
modify to make original factor labels of x survive

### DIFF
--- a/R/aglm-input.R
+++ b/R/aglm-input.R
@@ -161,9 +161,9 @@ newInput <- function(x,
     # For qualitative variables, holds ordered or unordered factor data
     if (vars_info[[i]]$type == "qual") {
       data_idx <- vars_info[[i]]$data_column_idx
-      if (vars_info[[i]]$use_OD) {
+      if (vars_info[[i]]$use_OD & !is.ordered(x[, data_idx])) {
         x[, data_idx] <- ordered(x[, data_idx])
-      } else {
+      } else if (!is.factor(x[, data_idx])) {
         x[, data_idx] <- factor(x[, data_idx])
       }
     }

--- a/R/predict-aglm.R
+++ b/R/predict-aglm.R
@@ -35,8 +35,8 @@ predict.AccurateGLM <- function(model,
     var_info <- model@vars_info[[i]]
     if (var_info$type == "quan") newx[, i] <- as.numeric(newx[, i])
     else if (var_info$type == "qual") {
-      if (var_info$use_OD) newx[, i] <- ordered(newx[, i])
-      else newx[, i] <- factor(newx[, i])
+      if (var_info$use_OD & !is.ordered(newx[, i])) newx[, i] <- ordered(newx[, i])
+      else if (!is.factor(newx[, i])) newx[, i] <- factor(newx[, i])
     }
   }
   newx <- new("AGLM_Input", vars_info=model@vars_info, data=newx)


### PR DESCRIPTION
Fixed to avoid recast input columns to ordered vectors, when they already have ordered types, because recasting drops information of original labels which are not included in inputs as values.