### PR TITLE
A LVar fix and add an `extrapolation` option.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,5 +19,6 @@ Imports:
 Suggests: 
     testthat,
     knitr,
-    rmarkdown
+    rmarkdown,
+    MASS
 VignetteBuilder: knitr

--- a/R/aglm-input.R
+++ b/R/aglm-input.R
@@ -271,7 +271,7 @@ getMatrixRepresentationByVector <- function(raw_vec, var_info, drop_OD=FALSE) {
     # It's expected that min is the first and max is the last, but calculate them for safety.
     x_vec <- pmax(pmin(x_vec, max(breaks)), min(breaks))
   } else {
-    assert_that(var_info$extrapolation == "default", msg="extrapolation must be 'default' or 'flat'.")
+    assert_that(var_info$extrapolation == "default", msg="extrapolation must be \"default\" or \"flat\".")
   }
 
   z <- NULL

--- a/R/aglm-input.R
+++ b/R/aglm-input.R
@@ -68,7 +68,6 @@ newInput <- function(x,
     }
     var$use_LV <- var$type == "quan" & use_LVar
     if (var$use_LV) {
-      var$use_linear <- FALSE
       var$use_OD <- FALSE
     }
     var$extrapolation <- extrapolation
@@ -153,7 +152,7 @@ newInput <- function(x,
     var <- vars_info[[i]]
     var$type <- "quan"
 
-    var$use_linear <- !use_LVar & add_linear_columns
+    var$use_linear <- add_linear_columns
     var$use_UD <- FALSE
     var$use_OD <- !use_LVar
     var$use_LV <- use_LVar
@@ -283,21 +282,27 @@ getMatrixRepresentationByVector <- function(raw_vec, var_info, drop_OD=FALSE) {
 
   if (var_info$use_LV & !drop_OD) {
     z_LV <- getLVarMatForOneVec(x_vec, breaks=var_info$LV_info$breaks)$dummy_mat
-    colnames(z_LV) <- paste0(var_info$name, "_LV_", seq(dim(z_LV)[2]))
-    z <- cbind(z, z_LV)
+    if (!is.null(z_LV)) {
+      colnames(z_LV) <- paste0(var_info$name, "_LV_", seq(dim(z_LV)[2]))
+      z <- cbind(z, z_LV)
+    }
   }
 
   if (var_info$use_OD & !drop_OD) {
     z_OD <- getODummyMatForOneVec(x_vec, breaks=var_info$OD_info$breaks, dummy_type=var_info$OD_type)$dummy_mat
-    colnames(z_OD) <- paste0(var_info$name, "_OD_", seq(dim(z_OD)[2]))
-    z <- cbind(z, z_OD)
+    if (!is.null(z_LV)) {
+      colnames(z_OD) <- paste0(var_info$name, "_OD_", seq(dim(z_OD)[2]))
+      z <- cbind(z, z_OD)
+    }
   }
 
   if (var_info$use_UD) {
     z_UD <- getUDummyMatForOneVec(x_vec, levels=var_info$UD_info$levels,
                                   drop_last=var_info$UD_info$drop_last)$dummy_mat
-    colnames(z_UD) <- paste0(var_info$name, "_UD_", seq(dim(z_UD)[2]))
-    z <- cbind(z, z_UD)
+    if (!is.null(z_LV)) {
+      colnames(z_UD) <- paste0(var_info$name, "_UD_", seq(dim(z_UD)[2]))
+      z <- cbind(z, z_UD)
+    }
   }
 
   return(z)

--- a/R/aglm-input.R
+++ b/R/aglm-input.R
@@ -212,8 +212,9 @@ newInput <- function(x,
       for (i in seq(length(bins_list))) {
         name <- bins_names[[i]]
         idx <- idx_map[[name]]
-        if (vars_info[[idx]]$use_OD) vars_info[[idx]]$OD_info$breaks <- bins_list[[i]]
-        if (vars_info[[idx]]$use_LV) vars_info[[idx]]$LV_info$breaks <- bins_list[[i]]
+        breaks <- bins_list[[i]]
+        if (vars_info[[idx]]$use_OD) vars_info[[idx]]$OD_info$breaks <- unique(sort(breaks[is.finite(breaks)]))
+        if (vars_info[[idx]]$use_LV) vars_info[[idx]]$LV_info$breaks <- unique(sort(breaks[is.finite(breaks)]))
       }
     }
   }

--- a/R/aglm-input.R
+++ b/R/aglm-input.R
@@ -22,7 +22,7 @@ newInput <- function(x,
                      add_linear_columns=TRUE,
                      add_OD_columns_of_qualitatives=TRUE,
                      add_interaction_columns=TRUE,
-                     OD_type_of_quantitatives='C',
+                     OD_type_of_quantitatives="C",
                      nbin.max=NULL,
                      bins_list=NULL,
                      bins_names=NULL) {
@@ -52,11 +52,11 @@ newInput <- function(x,
 
     var$use_linear <- var$type == "quan" & add_linear_columns
     var$use_UD <- var$type == "qual"
-    var$use_OD <- (var$type == "quan" & OD_type_of_quantitatives != 'N') |
+    var$use_OD <- (var$type == "quan" & OD_type_of_quantitatives != "N") |
       (var$type == "qual" & is_ordered & add_OD_columns_of_qualitatives)
     if (var$use_OD) {
       if (var$type == "quan") var$OD_type <- OD_type_of_quantitatives
-      else var$OD_type <- 'J'
+      else var$OD_type <- "J"
     } else {
       if (var$type == "quan") {
         # Even cases not using O-dummies for quantitatives,

--- a/R/aglm-input.R
+++ b/R/aglm-input.R
@@ -290,7 +290,7 @@ getMatrixRepresentationByVector <- function(raw_vec, var_info, drop_OD=FALSE) {
 
   if (var_info$use_OD & !drop_OD) {
     z_OD <- getODummyMatForOneVec(x_vec, breaks=var_info$OD_info$breaks, dummy_type=var_info$OD_type)$dummy_mat
-    if (!is.null(z_LV)) {
+    if (!is.null(z_OD)) {
       colnames(z_OD) <- paste0(var_info$name, "_OD_", seq(dim(z_OD)[2]))
       z <- cbind(z, z_OD)
     }
@@ -299,7 +299,7 @@ getMatrixRepresentationByVector <- function(raw_vec, var_info, drop_OD=FALSE) {
   if (var_info$use_UD) {
     z_UD <- getUDummyMatForOneVec(x_vec, levels=var_info$UD_info$levels,
                                   drop_last=var_info$UD_info$drop_last)$dummy_mat
-    if (!is.null(z_LV)) {
+    if (!is.null(z_UD)) {
       colnames(z_UD) <- paste0(var_info$name, "_UD_", seq(dim(z_UD)[2]))
       z <- cbind(z, z_UD)
     }

--- a/R/aglm-input.R
+++ b/R/aglm-input.R
@@ -18,6 +18,7 @@ newInput <- function(x,
                      qualitative_vars_OD_only=NULL,
                      quantitative_vars=NULL,
                      use_LVar=FALSE,
+                     extrapolation="default",
                      add_linear_columns=TRUE,
                      add_OD_columns_of_qualitatives=TRUE,
                      add_interaction_columns=TRUE,
@@ -70,6 +71,7 @@ newInput <- function(x,
       var$use_linear <- FALSE
       var$use_OD <- FALSE
     }
+    var$extrap <- extrapolation
 
     vars_info[[i]] <- var
   }
@@ -264,12 +266,17 @@ getMatrixRepresentationByVector <- function(raw_vec, var_info, drop_OD=FALSE) {
   z <- NULL
 
   if (var_info$use_linear) {
+    if (var_info$extrap == "flat") {
+      raw_vec <- pmax(pmin(raw_vec, max(var_info$OD_info$breaks)), min(var_info$OD_info$breaks))
+    } else if (var_info$extrap != "default") {
+      assert_that(FALSE, msg="extrap must be 'default' or 'flat'.")
+    }
     z <- matrix(raw_vec, ncol=1)
     colnames(z) <- var_info$name
   }
 
   if (var_info$use_LV & !drop_OD) {
-    z_LV <- getLVarMatForOneVec(raw_vec, breaks=var_info$LV_info$breaks)$dummy_mat
+    z_LV <- getLVarMatForOneVec(raw_vec, breaks=var_info$LV_info$breaks, extrapolation=var_info$extrap)$dummy_mat
     colnames(z_LV) <- paste0(var_info$name, "_LV_", seq(dim(z_LV)[2]))
     z <- cbind(z, z_LV)
   }

--- a/R/aglm.R
+++ b/R/aglm.R
@@ -11,7 +11,9 @@
 #' @param qualitative_vars_OD_only A list of indices or names for specifying which columns are qualitative and need only O-dummy representations.
 #' @param quantitative_vars A list of indices or names for specyfying which columns are quantitative.
 #' @param use_LVar A boolean value which indicates whether this function uses L-variable representations or not.
-#' @param extrapolation A type how extrapolate for left boundary. ('flat' or 'default')
+#' @param extrapolation A character value which indicates how contribution curves outside bins are extrapolated.
+#'   * "default": No extrapolations.
+#'   * "flat": Extrapolates with flat lines.
 #' @param add_linear_columns A boolean value which indicates whether this function uses linear effects or not.
 #' @param add_OD_columns_of_qualitatives A boolean value which indicates whether this function use O-dummy representations for qualitative and ordinal variables or not.
 #' @param add_interaction_columns A boolean value which indicates whether this function uses intersection effects or not.

--- a/R/aglm.R
+++ b/R/aglm.R
@@ -11,6 +11,7 @@
 #' @param qualitative_vars_OD_only A list of indices or names for specifying which columns are qualitative and need only O-dummy representations.
 #' @param quantitative_vars A list of indices or names for specyfying which columns are quantitative.
 #' @param use_LVar A boolean value which indicates whether this function uses L-variable representations or not.
+#' @param extrapolation A type how extrapolate for left boundary. ('flat' or 'default')
 #' @param add_linear_columns A boolean value which indicates whether this function uses linear effects or not.
 #' @param add_OD_columns_of_qualitatives A boolean value which indicates whether this function use O-dummy representations for qualitative and ordinal variables or not.
 #' @param add_interaction_columns A boolean value which indicates whether this function uses intersection effects or not.
@@ -36,6 +37,7 @@ aglm <- function(x, y,
                  qualitative_vars_OD_only=NULL,
                  quantitative_vars=NULL,
                  use_LVar=FALSE,
+                 extrapolation="default",
                  add_linear_columns=TRUE,
                  add_OD_columns_of_qualitatives=TRUE,
                  add_interaction_columns=FALSE,
@@ -52,6 +54,7 @@ aglm <- function(x, y,
                 qualitative_vars_OD_only=qualitative_vars_OD_only,
                 quantitative_vars=quantitative_vars,
                 use_LVar=use_LVar,
+                extrapolation=extrapolation,
                 add_linear_columns=add_linear_columns,
                 add_OD_columns_of_qualitatives=add_OD_columns_of_qualitatives,
                 add_interaction_columns=add_interaction_columns,

--- a/R/aglm.R
+++ b/R/aglm.R
@@ -16,10 +16,10 @@
 #' @param add_OD_columns_of_qualitatives A boolean value which indicates whether this function use O-dummy representations for qualitative and ordinal variables or not.
 #' @param add_interaction_columns A boolean value which indicates whether this function uses intersection effects or not.
 #' @param OD_type_of_quantitatives A character value which indicates how O-dummy matrices of quantitative
-#'   values are constructed. Choose 'C'(default) or 'J'.
-#'   * 'C': Continuous-type dummies, which result continuous contribution curves.
-#'   * 'J': Jum-type dummies, which result contribution curves with jumps.
-#'   * 'N': No use of O-dummies
+#'   values are constructed. Choose "C"(default) or "J".
+#'   * "C": Continuous-type dummies, which result continuous contribution curves.
+#'   * "J": Jump-type dummies, which result contribution curves with jumps.
+#'   * "N": No use of O-dummies
 #' @param family Response type. Currently "gaussian", "binomial", and "poisson" are supported.
 #' @param nbin.max a maximum number of bins which is automatically generated. Only used when `breaks` is not set.
 #' @param bins_list A list of numeric vectors, each element of which is used as breaks when binning of a quantitative variable or a qualitative variable with order.
@@ -41,7 +41,7 @@ aglm <- function(x, y,
                  add_linear_columns=TRUE,
                  add_OD_columns_of_qualitatives=TRUE,
                  add_interaction_columns=FALSE,
-                 OD_type_of_quantitatives='C',
+                 OD_type_of_quantitatives="C",
                  nbin.max=NULL,
                  bins_list=NULL,
                  bins_names=NULL,

--- a/R/coef-aglm.R
+++ b/R/coef-aglm.R
@@ -39,7 +39,8 @@ coef.AccurateGLM <- function(model, index=NULL, name=NULL, s=NULL, exact=FALSE, 
       if(var_info$use_UD) ncol_UD <- length(var_info$UD_info$levels) - var_info$UD_info$drop_last
 
       ncol_LV <- 0
-      if(var_info$use_LV) ncol_LV <- length(var_info$LV_info$breaks) - 1
+      # In case length(LV_info$breaks) <= 2, there are no internal breaks, and so only a linear column is created.
+      if(var_info$use_LV & length(var_info$LV_info$breaks) > 2) ncol_LV <- length(var_info$LV_info$breaks) - 2
 
       if (i == index) {
         c <- list()

--- a/R/coef-aglm.R
+++ b/R/coef-aglm.R
@@ -32,7 +32,7 @@ coef.AccurateGLM <- function(model, index=NULL, name=NULL, s=NULL, exact=FALSE, 
       ncol_OD <- 0
       if(var_info$use_OD) {
         ncol_OD <- length(var_info$OD_info$breaks)
-        if (var_info$OD_type == 'C') ncol_OD <- ncol_OD - 1
+        if (var_info$OD_type == "C") ncol_OD <- ncol_OD - 1
       }
 
       ncol_UD <- 0

--- a/R/cv-aglm.R
+++ b/R/cv-aglm.R
@@ -11,7 +11,9 @@
 #' @param qualitative_vars_OD_only A list of indices or names for specifying which columns are qualitative and need only O-dummy representations.
 #' @param quantitative_vars A list of indices or names for specyfying which columns are quantitative.
 #' @param use_LVar A boolean value which indicates whether this function uses L-variable representations or not.
-#' @param extrapolation A type how extrapolate for left boundary. ('flat' or 'default')
+#' @param extrapolation A character value which indicates how contribution curves outside bins are extrapolated.
+#'   * "default": No extrapolations.
+#'   * "flat": Extrapolates with flat lines.
 #' @param add_linear_columns A boolean value which indicates whether this function uses linear effects or not.
 #' @param add_OD_columns_of_qualitatives A boolean value which indicates whether this function use O-dummy representations for qualitative and ordinal variables or not.
 #' @param add_interaction_columns A boolean value which indicates whether this function uses interaction effects or not.

--- a/R/cv-aglm.R
+++ b/R/cv-aglm.R
@@ -11,6 +11,7 @@
 #' @param qualitative_vars_OD_only A list of indices or names for specifying which columns are qualitative and need only O-dummy representations.
 #' @param quantitative_vars A list of indices or names for specyfying which columns are quantitative.
 #' @param use_LVar A boolean value which indicates whether this function uses L-variable representations or not.
+#' @param extrapolation A type how extrapolate for left boundary. ('flat' or 'default')
 #' @param add_linear_columns A boolean value which indicates whether this function uses linear effects or not.
 #' @param add_OD_columns_of_qualitatives A boolean value which indicates whether this function use O-dummy representations for qualitative and ordinal variables or not.
 #' @param add_interaction_columns A boolean value which indicates whether this function uses interaction effects or not.
@@ -36,6 +37,7 @@ cv.aglm <- function(x, y,
                     qualitative_vars_OD_only=NULL,
                     quantitative_vars=NULL,
                     use_LVar=FALSE,
+                    extrapolation="default",
                     add_linear_columns=TRUE,
                     add_OD_columns_of_qualitatives=TRUE,
                     add_interaction_columns=FALSE,
@@ -53,6 +55,7 @@ cv.aglm <- function(x, y,
                 qualitative_vars_OD_only=qualitative_vars_OD_only,
                 quantitative_vars=quantitative_vars,
                 use_LVar=use_LVar,
+                extrapolation=extrapolation,
                 add_linear_columns=add_linear_columns,
                 add_OD_columns_of_qualitatives=add_OD_columns_of_qualitatives,
                 add_interaction_columns=add_interaction_columns,

--- a/R/cv-aglm.R
+++ b/R/cv-aglm.R
@@ -16,10 +16,10 @@
 #' @param add_OD_columns_of_qualitatives A boolean value which indicates whether this function use O-dummy representations for qualitative and ordinal variables or not.
 #' @param add_interaction_columns A boolean value which indicates whether this function uses interaction effects or not.
 #' @param OD_type_of_quantitatives A character value which indicates how O-dummy matrices of quantitative
-#'   values are constructed. Choose 'C'(default) or 'J'.
-#'   * 'C': Continuous-type dummies, which result continuous contribution curves.
-#'   * 'J': Jum-type dummies, which result contribution curves with jumps.
-#'   * 'N': No use of O-dummies
+#'   values are constructed. Choose "C"(default) or "J".
+#'   * "C": Continuous-type dummies, which result continuous contribution curves.
+#'   * "J": Jump-type dummies, which result contribution curves with jumps.
+#'   * "N": No use of O-dummies
 #' @param family Response type. Currently "gaussian", "binomial", and "poisson" are supported.
 #' @param nbin.max a maximum number of bins which is automatically generated. Only used when `breaks` is not set.
 #' @param bins_list A list of numeric vectors, each element of which is used as breaks when binning of a quantitative variable or a qualitative variable with order.
@@ -41,7 +41,7 @@ cv.aglm <- function(x, y,
                     add_linear_columns=TRUE,
                     add_OD_columns_of_qualitatives=TRUE,
                     add_interaction_columns=FALSE,
-                    OD_type_of_quantitatives='C',
+                    OD_type_of_quantitatives="C",
                     nbin.max=NULL,
                     bins_list=NULL,
                     bins_names=NULL,

--- a/R/get-dummies.R
+++ b/R/get-dummies.R
@@ -125,11 +125,14 @@ getLVarMatForOneVec <- function(x_vec, breaks=NULL, nbin.max=100, only_info=FALS
 
   # create dummy matrix for x_vec
   nrow <- length(x_vec)
-  ncol <- length(binned_x$breaks) - 1
-  X <- matrix(x_vec, nrow, ncol)
-  B0 <- t(matrix(binned_x$breaks[1:ncol], ncol, nrow))
-  dummy_mat <- abs(X - B0)
-  dummy_mat[, 1] <- (X- B0)[, 1]
+  ncol <- length(binned_x$breaks) - 2
+  if (ncol < 1) {
+    dummy_mat <- NULL
+  } else {
+    X <- matrix(x_vec, nrow, ncol)
+    B0 <- t(matrix(binned_x$breaks[2:(ncol + 1)], ncol, nrow))
+    dummy_mat <- abs(X - B0)
+  }
 
   if (only_info) return(list(breaks=binned_x$breaks))
   else return(list(breaks=binned_x$breaks, dummy_mat=dummy_mat))

--- a/R/get-dummies.R
+++ b/R/get-dummies.R
@@ -48,10 +48,10 @@ getUDummyMatForOneVec <- function(x_vec, levels=NULL, drop_last=TRUE, only_info=
 #'   If NULL, evenly cut bins are automatically generated and used.
 #' @param nbin.max A maximum number of bins which is used. Only used when `breaks` is not set.
 #' @param only_info A boolean value. If TRUE, actual creation of dummy matrix is omitted.
-#' @param dummy_type A character value. Choose 'C'(default) or 'J'. For integer or numeric `x_vec`,
-#'  `dummy_type='C'` is used as default. Otherwise, `dummy_type='J'` is used as default.
-#'   * 'C': Continuous-type dummies, which result continuous contribution curves.
-#'   * 'J': Jum-type dummies, which result contribution curves with jumps.
+#' @param dummy_type A character value. Choose "C"(default) or "J". For integer or numeric `x_vec`,
+#'  `dummy_type="C"` is used as default. Otherwise, `dummy_type="J"` is used as default.
+#'   * "C": Continuous-type dummies, which result continuous contribution curves.
+#'   * "J": Jum-type dummies, which result contribution curves with jumps.
 #'
 #' @return a list with two members `breaks` and `dummy_mat`.
 #' * `breaks`: Same as input
@@ -68,15 +68,15 @@ getODummyMatForOneVec <- function(x_vec, breaks=NULL, nbin.max=100, only_info=FA
   # Check arguments. only integer or numerical or ordered vectors are allowed.
   assert_that(is.integer(x_vec) | is.numeric(x_vec) | is.ordered(x_vec))
   if (is.null(dummy_type)) {
-    if (is.ordered(x_vec)) dummy_type <- 'J'
-    else dummy_type <- 'C'
+    if (is.ordered(x_vec)) dummy_type <- "J"
+    else dummy_type <- "C"
   }
 
   # Execute binning
   binned_x <- executeBinning(x_vec, breaks=breaks, nbin.max=nbin.max)
 
   # create dummy matrix for x_vec
-  if (dummy_type == 'C') {
+  if (dummy_type == "C") {
     nrow <- length(x_vec)
     ncol <- length(binned_x$breaks) - 1
     X <- matrix(x_vec, nrow, ncol)
@@ -85,12 +85,12 @@ getODummyMatForOneVec <- function(x_vec, breaks=NULL, nbin.max=100, only_info=FA
     dummy_mat <- (X - B0) / (B1 - B0)
     dummy_mat[dummy_mat <= 0] <- 0
     dummy_mat[dummy_mat >= 1] <- 1
-  } else if (dummy_type == 'J') {
+  } else if (dummy_type == "J") {
     nrow <- length(x_vec)
     ncol <- length(binned_x$breaks)
     dummy_mat <- 1 * (binned_x$labels > t(matrix(1:ncol, ncol, nrow)))
   } else {
-    assert_that(FALSE, msg="dummy_type must be 'C' or 'J'.")
+    assert_that(FALSE, msg="dummy_type must be \"C\" or \"J\".")
   }
 
   if (only_info) return(list(breaks=binned_x$breaks))

--- a/R/get-dummies.R
+++ b/R/get-dummies.R
@@ -104,6 +104,7 @@ getODummyMatForOneVec <- function(x_vec, breaks=NULL, nbin.max=100, only_info=FA
 #'   If NULL, evenly cut bins are automatically generated and used.
 #' @param nbin.max A maximum number of bins which is used. Only used when `breaks` is not set.
 #' @param only_info A boolean value. If TRUE, actual creation of dummy matrix is omitted.
+#' @param extrapolation A type how extrapolate for left boundary. ('flat' or 'default')
 #'
 #' @return a list with two members `breaks` and `dummy_mat`.
 #' * `breaks`: Same as input
@@ -116,12 +117,18 @@ getODummyMatForOneVec <- function(x_vec, breaks=NULL, nbin.max=100, only_info=FA
 #'
 #' @export
 #' @importFrom assertthat assert_that
-getLVarMatForOneVec <- function(x_vec, breaks=NULL, nbin.max=100, only_info=FALSE) {
-  # Check arguments. only integer or numerical or ordered vectors are allowed.
+getLVarMatForOneVec <- function(x_vec, breaks=NULL, nbin.max=100, only_info=FALSE, extrapolation="default") {
+    # Check arguments. only integer or numerical or ordered vectors are allowed.
   assert_that(is.integer(x_vec) | is.numeric(x_vec) | is.ordered(x_vec))
 
   # Execute binning
   binned_x <- executeBinning(x_vec, breaks=breaks, nbin.max=nbin.max)
+
+  if (extrapolation == "flat"){
+    x_vec <- pmax(pmin(x_vec, max(binned_x$breaks)), min(binned_x$breaks))
+  } else if (extrapolation != "default") {
+    assert_that(FALSE, msg="extrapolation must be 'default' or 'flat'.")
+  }
 
   # create dummy matrix for x_vec
   nrow <- length(x_vec)
@@ -129,6 +136,7 @@ getLVarMatForOneVec <- function(x_vec, breaks=NULL, nbin.max=100, only_info=FALS
   X <- matrix(x_vec, nrow, ncol)
   B0 <- t(matrix(binned_x$breaks[1:ncol], ncol, nrow))
   dummy_mat <- abs(X - B0)
+  dummy_mat[, 1] <- (X- B0)[, 1]
 
   if (only_info) return(list(breaks=binned_x$breaks))
   else return(list(breaks=binned_x$breaks, dummy_mat=dummy_mat))

--- a/R/get-dummies.R
+++ b/R/get-dummies.R
@@ -104,7 +104,6 @@ getODummyMatForOneVec <- function(x_vec, breaks=NULL, nbin.max=100, only_info=FA
 #'   If NULL, evenly cut bins are automatically generated and used.
 #' @param nbin.max A maximum number of bins which is used. Only used when `breaks` is not set.
 #' @param only_info A boolean value. If TRUE, actual creation of dummy matrix is omitted.
-#' @param extrapolation A type how extrapolate for left boundary. ('flat' or 'default')
 #'
 #' @return a list with two members `breaks` and `dummy_mat`.
 #' * `breaks`: Same as input
@@ -117,18 +116,12 @@ getODummyMatForOneVec <- function(x_vec, breaks=NULL, nbin.max=100, only_info=FA
 #'
 #' @export
 #' @importFrom assertthat assert_that
-getLVarMatForOneVec <- function(x_vec, breaks=NULL, nbin.max=100, only_info=FALSE, extrapolation="default") {
-    # Check arguments. only integer or numerical or ordered vectors are allowed.
+getLVarMatForOneVec <- function(x_vec, breaks=NULL, nbin.max=100, only_info=FALSE) {
+  # Check arguments. only integer or numerical or ordered vectors are allowed.
   assert_that(is.integer(x_vec) | is.numeric(x_vec) | is.ordered(x_vec))
 
   # Execute binning
   binned_x <- executeBinning(x_vec, breaks=breaks, nbin.max=nbin.max)
-
-  if (extrapolation == "flat"){
-    x_vec <- pmax(pmin(x_vec, max(binned_x$breaks)), min(binned_x$breaks))
-  } else if (extrapolation != "default") {
-    assert_that(FALSE, msg="extrapolation must be 'default' or 'flat'.")
-  }
 
   # create dummy matrix for x_vec
   nrow <- length(x_vec)

--- a/examples/LVar.R
+++ b/examples/LVar.R
@@ -1,5 +1,5 @@
-library(MASS) # For Boston
 library(aglm)
+library(MASS) # For Boston
 
 ## Read data
 xy <- Boston # xy is a data.frame to be processed.
@@ -18,3 +18,32 @@ cat("lambda.min: ", lambda.min, "\n")
 ## Plots coefs of cross-validated model
 plot(cv.model, s=cv.model@lambda.min, resid=TRUE, add_rug=TRUE)
 
+## Sample data for extrapolation parameter
+SEED <- 2021
+sd <- 0.2
+set.seed(SEED)
+x <- 2 * runif(1000) + 1
+f <- function(x){x^3 - 6 * x^2 + 12 * x}
+y <- f(x) + rnorm(1000, sd = sd)
+xy <- data.frame(x=x, y=y)
+x_test <- seq(0.75, 3.25, length.out=101)
+y_test <- f(x_test) + rnorm(101, sd=sd)
+xy_test <- data.frame(x=x_test, y=y_test)
+
+## Sample plot for extrapolation="default"
+set.seed(SEED)
+model <- cv.aglm(x, y, use_LVar=TRUE)
+pred <- predict(model, newx=x_test, s=model@lambda.min, type="response")
+plot(x_test, y_test, pch=20, main="extrapolation='default'")
+lines(x_test, pred, col="red")
+lines(x_test, f(x_test))
+plot(model, s=model@lambda.min, layout=c(1, 1), main="extrapolation='default'")
+
+## Sample plot for extrapolation="flat"
+set.seed(SEED)
+model <- cv.aglm(x, y, use_LVar=TRUE, extrapolation="flat")
+pred <- predict(model, newx=x_test, s=model@lambda.min, type="response")
+plot(x_test, y_test, pch=20, main="extrapolation='flat'")
+lines(x_test, pred, col="red")
+lines(x_test, f(x_test))
+plot(model, s=model@lambda.min, layout=c(1, 1), main="extrapolation='flat'")

--- a/examples/LVar.R
+++ b/examples/LVar.R
@@ -1,5 +1,5 @@
-library(aglm)
 library(MASS) # For Boston
+library(aglm)
 
 ## Read data
 xy <- Boston # xy is a data.frame to be processed.
@@ -17,33 +17,3 @@ cat("lambda.min: ", lambda.min, "\n")
 
 ## Plots coefs of cross-validated model
 plot(cv.model, s=cv.model@lambda.min, resid=TRUE, add_rug=TRUE)
-
-## Sample data for extrapolation parameter
-SEED <- 2021
-sd <- 0.2
-set.seed(SEED)
-x <- 2 * runif(1000) + 1
-f <- function(x){x^3 - 6 * x^2 + 12 * x}
-y <- f(x) + rnorm(1000, sd = sd)
-xy <- data.frame(x=x, y=y)
-x_test <- seq(0.75, 3.25, length.out=101)
-y_test <- f(x_test) + rnorm(101, sd=sd)
-xy_test <- data.frame(x=x_test, y=y_test)
-
-## Sample plot for extrapolation="default"
-set.seed(SEED)
-model <- cv.aglm(x, y, use_LVar=TRUE)
-pred <- predict(model, newx=x_test, s=model@lambda.min, type="response")
-plot(x_test, y_test, pch=20, main="extrapolation='default'")
-lines(x_test, pred, col="red")
-lines(x_test, f(x_test))
-plot(model, s=model@lambda.min, layout=c(1, 1), main="extrapolation='default'")
-
-## Sample plot for extrapolation="flat"
-set.seed(SEED)
-model <- cv.aglm(x, y, use_LVar=TRUE, extrapolation="flat")
-pred <- predict(model, newx=x_test, s=model@lambda.min, type="response")
-plot(x_test, y_test, pch=20, main="extrapolation='flat'")
-lines(x_test, pred, col="red")
-lines(x_test, f(x_test))
-plot(model, s=model@lambda.min, layout=c(1, 1), main="extrapolation='flat'")

--- a/examples/extrapolation.R
+++ b/examples/extrapolation.R
@@ -1,0 +1,37 @@
+library(MASS) # For Boston
+library(aglm)
+
+## Randomly created train and test data
+set.seed(2021)
+sd <- 0.2
+x <- 2 * runif(1000) + 1
+f <- function(x){x^3 - 6 * x^2 + 13 * x}
+y <- f(x) + rnorm(1000, sd = sd)
+xy <- data.frame(x=x, y=y)
+x_test <- seq(0.75, 3.25, length.out=101)
+y_test <- f(x_test) + rnorm(101, sd=sd)
+xy_test <- data.frame(x=x_test, y=y_test)
+
+## Sample plot for extrapolation="default"
+models <- c(cv.aglm(x, y, extrapolation="default"),
+            cv.aglm(x, y, extrapolation="flat"),
+            cv.aglm(x, y, use_LVar=TRUE, extrapolation="default"),
+            cv.aglm(x, y, use_LVar=TRUE, extrapolation="flat"))
+
+titles <- c("O-Dummies with extrapolation=\"default\"",
+            "O-Dummies with extrapolation=\"flat\"",
+            "L-Variables with extrapolation=\"default\"",
+            "L-Variables with extrapolation=\"flat\"")
+
+par.old <- par(mfrow=c(2, 2))
+for (i in 1:4) {
+  model <- models[[i]]
+  title <- titles[[i]]
+
+  pred <- predict(model, newx=x_test, s=model@lambda.min, type="response")
+
+  plot(x_test, y_test, pch=20, col="grey", main=title)
+  lines(x_test, f(x_test), lty="dashed", lwd=2)  # the theoretical line
+  lines(x_test, pred, col="blue", lwd=3)  # the smoothed line by the model
+}
+par(par.old)

--- a/tests/testthat/test_LVar.R
+++ b/tests/testthat/test_LVar.R
@@ -2,17 +2,11 @@ context("LVar")
 library(aglm)
 
 test_that("getLVarMatForOneVec()'s outputs are correct.", {
-  expect_equal(getLVarMatForOneVec(1:3)$dummy_mat, matrix(c(0, 1, 2, 1, 0, 1), 3, 2))
-  expect_equal(getLVarMatForOneVec(1:3, extrapolation="flat")$dummy_mat,
-               matrix(c(0, 1, 2, 1, 0, 1), 3, 2))
+  expect_equal(getLVarMatForOneVec(1:3)$dummy_mat, matrix(c(1, 0, 1), 3, 1))
   expect_equal(getLVarMatForOneVec(c(1, 1.5, 2, 2.3, 3), breaks=1:3)$dummy_mat,
-               matrix(c(0, 0.5, 1, 1.3, 2, 1, 0.5, 0, 0.3, 1), 5, 2))
-  expect_equal(getLVarMatForOneVec(c(1, 1.5, 2, 2.3, 3), breaks=1:3, extrapolation="flat")$dummy_mat,
-               matrix(c(0, 0.5, 1, 1.3, 2, 1, 0.5, 0, 0.3, 1), 5, 2))
+               matrix(c(1, 0.5, 0, 0.3, 1), 5, 1))
   expect_equal(getLVarMatForOneVec(c(1, 1.5, 2, 2.3, 3), breaks=c(0, 1.8, 4))$dummy_mat,
-               matrix(c(1, 1.5, 2, 2.3, 3, 0.8, 0.3, 0.2, 0.5, 1.2), 5, 2))
-  expect_equal(getLVarMatForOneVec(c(1, 1.5, 2, 2.3, 3), breaks=c(0, 1.8, 4), extrapolation="flat")$dummy_mat,
-               matrix(c(1, 1.5, 2, 2.3, 3, 0.8, 0.3, 0.2, 0.5, 1.2), 5, 2))
+               matrix(c(0.8, 0.3, 0.2, 0.5, 1.2), 5, 1))
 })
 
 createX <- function(nobs, nvar_numeric, seed=12345) {
@@ -31,7 +25,7 @@ test_that("Check newInput() for L-Variable", {
   expect_equal(x@vars_info[[1]]$id, 1)
   expect_equal(x@vars_info[[1]]$data_column_idx, 1)
   expect_equal(x@vars_info[[1]]$type, "quan")
-  expect_equal(x@vars_info[[1]]$use_linear, FALSE)
+  expect_equal(x@vars_info[[1]]$use_linear, TRUE)
   expect_equal(x@vars_info[[1]]$use_UD, FALSE)
   expect_equal(x@vars_info[[1]]$use_OD, FALSE)
   expect_equal(x@vars_info[[1]]$use_LV, TRUE)
@@ -40,8 +34,10 @@ test_that("Check newInput() for L-Variable", {
   expect_true(!is.null(x@vars_info[[1]]$LV_info))
 
   mat_num <- getDesignMatrix(x)
-  expect_equal(mat_num[,1], x@data[,1]-min(x@data[,1]))
-  expect_equal(dim(mat_num), c(10, dim(getLVarMatForOneVec(mat_num[,1])$dummy_mat)[2]))
+  expect_equal(mat_num[,1], x@data[,1])
+  # '+1' for the linear column
+  ncol <- dim(getLVarMatForOneVec(mat_num[,1])$dummy_mat)[2] + 1
+  expect_equal(dim(mat_num), c(10, ncol))
 
   bins_list <- list(c(0, 1, 2))
   x <- newInput(createX(10, 1), use_LVar=TRUE, bins_list=bins_list)

--- a/tests/testthat/test_LVar.R
+++ b/tests/testthat/test_LVar.R
@@ -3,9 +3,15 @@ library(aglm)
 
 test_that("getLVarMatForOneVec()'s outputs are correct.", {
   expect_equal(getLVarMatForOneVec(1:3)$dummy_mat, matrix(c(0, 1, 2, 1, 0, 1), 3, 2))
+  expect_equal(getLVarMatForOneVec(1:3, extrapolation="flat")$dummy_mat,
+               matrix(c(0, 1, 2, 1, 0, 1), 3, 2))
   expect_equal(getLVarMatForOneVec(c(1, 1.5, 2, 2.3, 3), breaks=1:3)$dummy_mat,
                matrix(c(0, 0.5, 1, 1.3, 2, 1, 0.5, 0, 0.3, 1), 5, 2))
+  expect_equal(getLVarMatForOneVec(c(1, 1.5, 2, 2.3, 3), breaks=1:3, extrapolation="flat")$dummy_mat,
+               matrix(c(0, 0.5, 1, 1.3, 2, 1, 0.5, 0, 0.3, 1), 5, 2))
   expect_equal(getLVarMatForOneVec(c(1, 1.5, 2, 2.3, 3), breaks=c(0, 1.8, 4))$dummy_mat,
+               matrix(c(1, 1.5, 2, 2.3, 3, 0.8, 0.3, 0.2, 0.5, 1.2), 5, 2))
+  expect_equal(getLVarMatForOneVec(c(1, 1.5, 2, 2.3, 3), breaks=c(0, 1.8, 4), extrapolation="flat")$dummy_mat,
                matrix(c(1, 1.5, 2, 2.3, 3, 0.8, 0.3, 0.2, 0.5, 1.2), 5, 2))
 })
 


### PR DESCRIPTION
See PR #53 by @kazuzowo by the source.

### A LVar fix
For LVar, a contribution curve were represented as `\beta_1|x - b_0| + ... + \beta_m|x - b_{m - 1}|` where `{b_i}` are breaks and `{\beta_i}` are regression coefficients. Furthermore, if `x_vec` is the data, it holds in default that `b_0=min(x_vec)` and  `b_m=max(x_vec)`.

However, in such situation, fitting is sometimes unstable because the first term `\beta_1|x - b_0|` for the range `x in (-\infty, b_0]` is not tied up with xvec, therefore with real data.\
So, we will change the curve as `\beta_1 * x + \beta_2|x - b_1| + ... + \beta_m|x - b_{m - 1}`.

*NOTE*: We need the first linear term because `m` terms and coefficients are necessary to determine slopes of `m` intervals `(b_0, b_1], (b_1, b_2], ..., (b_{m-1}, b_m]`.

### Extrapolation
Add a simple feature to extrapolate the right and left side of contribution curves as flat, and to make them not diverse.